### PR TITLE
fix(PyQt5): add keyword to pyqt5 dependency

### DIFF
--- a/profiles/chinstrap/desktop/package.accept_keywords/dev-qt
+++ b/profiles/chinstrap/desktop/package.accept_keywords/dev-qt
@@ -4,6 +4,7 @@ dev-python/PyQt5 ~*
 # required by dev-python/PyQt5 ~*
 dev-python/sip ~*
 dev-python/PyQt5-sip ~*
+dev-python/PyQt-builder ~*
 
 dev-qt/assistant ~*
 dev-qt/qtbluetooth ~*


### PR DESCRIPTION
Signed-off-by: Mark Gomersbach <markgomersbach@gmail.com>